### PR TITLE
Solucionado bug de regresión al trabajar en el servidor

### DIFF
--- a/src/Kafe.py
+++ b/src/Kafe.py
@@ -1,11 +1,9 @@
 import sys
 import pathlib
-import io
 from antlr4 import InputStream, CommonTokenStream
 from Kafe_GrammarLexer import Kafe_GrammarLexer
 from Kafe_GrammarParser import Kafe_GrammarParser
 from EvalVisitorPrimitivo import EvalVisitorPrimitivo
-
 
 def main():
     # Verificar argumento del archivo .kf
@@ -22,10 +20,6 @@ def main():
 
     contenido = filepath.read_text(encoding='utf-8')
 
-    # 🔥 Capturar stdout
-    old_stdout = sys.stdout
-    sys.stdout = mystdout = io.StringIO()
-
     visitor = EvalVisitorPrimitivo()
     visitor.current_dir = filepath.parent
 
@@ -36,11 +30,6 @@ def main():
     tree = parser.program()
 
     visitor.visit(tree)
-
-
-    sys.stdout = old_stdout
-
-    print(mystdout.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Descripción
El bug consistía en que la salida de la ejecución de los programas se almacenaba temporalmente y se mostraba al finalizar la ejecución.

Esto provocaba que no se mostrara texto al ejecutar la función pour, lo que se evidencia al ejecutar el `test4.k` del directorio `base`.

> [!IMPORTANT]
> Se necesita buscar una nueva forma para que el servidor siga funcionando